### PR TITLE
[update] ignore pyright point

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -1,3 +1,4 @@
+# pyright: reportPrivateImportUsage = false
 import datetime
 import inspect
 import os


### PR DESCRIPTION
## 概要
- pyrightの警告が発生する

## 詳細
- https://github.com/yamazaki-seiya/homeru_kun/runs/3724388547?check_suite_focus=true
- pyrightの「reportPrivateImportUsage」警告の無視設定
  - 最新のpyrightで追加された警告
    - pyrightは常に最新が適用されるようになっている
  - https://github.com/microsoft/pyright/releases/tag/1.1.168
  - https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings
  - 内容を読むとどうやら警告を受けているWebClientの使い方、import方法が悪いと言っているが、公式ドキュメントの使い方と同じなので悪くなさそうなので警告を無視する事にした
