### PR TITLE
ユーザーIDを抽出するための正規表現パターンをSubteamID対応のものに変更

### DIFF
--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -6,7 +6,7 @@ import re
 from slackbot.bot import listen_to
 
 # Slackへの投稿コメントからユーザーIDを抽出するための正規表現パターン
-_EXTRACT_USER_PATTERN = re.compile(r'<@\w+>')
+_EXTRACT_USER_PATTERN = re.compile(r'(<@\w*>)|(<\!subteam\^.*>)')
 
 
 @listen_to(r'.*@.*')


### PR DESCRIPTION
## 概要
- subteamがメンションされた場合でも反応できるように正規表現を更新した
## 詳細
- _EXTRACT_USER_PATTERNでマッチパターンを設定しているが、現状、個人ユーザのIDしか取得できなかった
- subteamについても取得できるよう正規表現を追加
## その他
- 関連issue
  - https://github.com/yamazaki-seiya/nobiru_kun/issues/119
  - close






