### PR TITLE
Update botmodule.py

### DIFF
--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -6,7 +6,7 @@ import re
 from slackbot.bot import listen_to
 
 # Slackへの投稿コメントからユーザーIDを抽出するための正規表現パターン
-_EXTRACT_USER_PATTERN = re.compile(r'(<@\w*>)|(<\!subteam\^.*>)')
+_EXTRACT_USER_PATTERN = re.compile(r'(<@\w*>|<\!subteam\^.*>)')
 
 
 @listen_to(r'.*@.*')


### PR DESCRIPTION
正規表現が正しく抽出されるように修正

## 概要
- 正規表現が複数グループに分けて取得されるようになっていたので、その部分を修正

## 詳細
```
>>> import re
>>> a = re.compile(r'(\d)|(\w)')
>>> re.findall(a, "1") 
[('1', '')]
>>> re.findall(a, "w") 
[('', 'w')]
>>> a = re.compile(r'(\d|\w)')   # 真ん中の)と(をなくす
>>> re.findall(a, "1")
['1']
>>> re.findall(a, "w") 
['w']
```


## その他
- 関連issue
  - close 
